### PR TITLE
ユーザーページの画面設計２

### DIFF
--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -12,7 +12,7 @@
     &__title {
       height: 100px;
       width: 600px;
-      color: black;
+      color:#333;
       font-size: 50px;
       font-weight: bold;
       margin-top: 60px;
@@ -45,9 +45,22 @@
     margin-top: 60px;
 
     &__field {
-      height: 50px;
+      height: 100px;
       width: 600px;
-    
+
+      &--label {
+        height: 50px;
+        font-size: 20px;
+        color: #333;
+        margin-top: 30px;
+      }
+
+      &--input {
+        input {
+          width: 600px;
+          padding: 10px;
+        }
+      }    
 
     }
     &__actions {

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -6,12 +6,13 @@
 
   &__left {  
     width: 400px;
+    margin-top: 60px;
 
     &__title {
       height: 100px;
       width: 400px;
       color: black;
-      font-size: 40px;
+      font-size: 50px;
       font-weight: bold;
       margin-top: 60px;
       text-align: center;
@@ -22,16 +23,18 @@
     }
 
     &__link {
-      height: 50px;
-      width: 150px;
-      border: 1px solid #00008B;
-      margin-left: 125px;
+      height: 40px;
+      width: 100px;
+      margin-left: 150px;
+      background-color: #333;
+      border-radius: 8px;
+      margin-top: 50px;
      
       &--font {
-        color:#00008B;
-        font-size: 24px;
+        color: white;
+        font-size: 20px;
         text-align: center;
-        line-height: 50px;
+        line-height: 40px;
       }
     }   
   }

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -45,8 +45,6 @@
     margin-top: 60px;
 
     &__field {
-      height: 100px;
-      width: 600px;
 
       &--label {
         height: 50px;

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -3,14 +3,15 @@
   display: flex;
   justify-content: flex-start;
   font-family: 'Hiragino Maru Gothic ProN';
+  margin-bottom: 60px;
 
   &__left {  
-    width: 400px;
+    width: 600px;
     margin-top: 60px;
 
     &__title {
       height: 100px;
-      width: 400px;
+      width: 600px;
       color: black;
       font-size: 50px;
       font-weight: bold;
@@ -25,7 +26,7 @@
     &__link {
       height: 40px;
       width: 100px;
-      margin-left: 150px;
+      margin-left: 250px;
       background-color: #333;
       border-radius: 8px;
       margin-top: 50px;
@@ -40,12 +41,24 @@
   }
 
   &__right {
+    width: calc(100% - 600px);
+    margin-top: 60px;
 
     &__field {
+      height: 50px;
+      width: 600px;
+    
 
     }
     &__actions {
-
+      height: 80px;
+      width: 200px;
+      margin-left: 250px;
+      background-color: #333;
+      border-radius: 10px;
+      margin-top: 50px;
+      color: white; 
+      font-size: 40px;
     }
-  }
+  } 
 }

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,5 +1,5 @@
 .header
-  .header_left
+  .header__left
     = link_to '/' do
       StationRarry
 
@@ -14,31 +14,32 @@
 
   .user__right
     .user__right__field
-      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+    = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
       = render "devise/shared/error_messages", resource: resource
       .user__right__field--label
-        = f.label :email
+        = f.label :ユーザー名
+        %br/
+      .user__right__field--input
+        = f.text_field :name, autofocus: true, autocomplete: "name"
+      .user__right__field--label
+        = f.label :'E-mail'
         %br/
         - if @minimum_password_length
-          %em
-            (#{@minimum_password_length} characters minimum)
           %br/
       .user__right__field--input
-        = f.email_field :email,
+        = f.email_field :email
       .user__right__field--label
-        = f.label :password, "New password"
+        = f.label :パスワード（6文字以上）  
         %br/
         - if @minimum_password_length
-          %em
-            (#{@minimum_password_length} characters minimum)
           %br/
       .user__right__field--input
         = f.password_field :password, autofocus: true, autocomplete: "new-password"
       .user__right__field--label
-        = f.label :password_confirmation, "Confirm new password"
+        = f.label :パスワード（確認用）
         %br/
       .user__right__field--input
         = f.password_field :password_confirmation, autocomplete: "new-password" 
-    = f.submit "変更する", class: 'user__right__actions'
+      = f.submit "変更する", class: 'user__right__actions'
 
 .footer

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -3,41 +3,42 @@
     = link_to '/' do
       StationRarry
 
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+.user
+  .user__left
+    .user__left__title
+      ユーザー情報編集
+    .user__left__link
+      = link_to '/users/sign_up' do
+        .user__left__link--font  
+          新規登録
+
+  .user__right
+    .user__right__field
+      = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .user__right__field--label
+        = f.label :email
+        %br/
+        - if @minimum_password_length
+          %em
+            (#{@minimum_password_length} characters minimum)
+          %br/
+      .user__right__field--input
+        = f.email_field :email,
+      .user__right__field--label
+        = f.label :password, "New password"
+        %br/
+        - if @minimum_password_length
+          %em
+            (#{@minimum_password_length} characters minimum)
+          %br/
+      .user__right__field--input
+        = f.password_field :password, autofocus: true, autocomplete: "new-password"
+      .user__right__field--label
+        = f.label :password_confirmation, "Confirm new password"
+        %br/
+      .user__right__field--input
+        = f.password_field :password_confirmation, autocomplete: "new-password" 
+    = f.submit "変更する", class: 'user__right__actions'
 
 .footer

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -11,18 +11,34 @@
       = link_to '/users/sign_in' do
         .user__left__link--font  
           ログイン
+  
   .user__right
     .user__right__field
-      = form_for(current_user) do |f|
-          .field-label
-            = f.label :name
-          .field-input
-            = f.text_field :name, autofocus: true
-        .field
-          .field-label
-            = f.label :email
-          .field-input
-            = f.email_field :email
-    = f.submit "登録する", class: 'user__right__actions'
+    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .user__right__field--label
+        = f.label :ユーザー名
+        %br/
+      .user__right__field--input
+        = f.email_field :name, autofocus: true, autocomplete: "name"
+      .user__right__field--label
+        = f.label :'E-mail'
+        %br/
+      .user__right__field--input
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+      .user__right__field--label
+        = f.label :パスワード（6文字以上）
+        - if @minimum_password_length
+          %em 
+        %br/  
+      .user__right__field--input
+        = f.password_field :password, autocomplete: "new-password"
+      .user__right__field--label
+        = f.label :パスワード（確認用）
+        %br/
+      .user__right__field--input
+        = f.password_field :password_confirmation, autocomplete: "resourcespassword" 
+      = f.submit "登録する", class: 'user__right__actions'
+    
 
 .footer

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -12,30 +12,17 @@
         .user__left__link--font  
           ログイン
   .user__right
-    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-      = render "devise/shared/error_messages", resource: resource
-      .user__right__field--label
-        = f.label :ユーザー名
-        %br/
-      .user__right__field--input
-        = f.email_field :name, autofocus: true, autocomplete: "name"
-      .user__right__field--label
-        = f.label :'E-mail'
-        %br/
-      .user__right__field--input
-        = f.email_field :email, autofocus: true, autocomplete: "email"
-      .user__right__field--label
-        = f.label :パスワード（6文字以上）
-        - if @minimum_password_length
-          %em 
-        %br/  
-      .user__right__field--input
-        = f.password_field :password, autocomplete: "new-password"
-      .user__right__field--label
-        = f.label :パスワード（確認用）
-        %br/
-      .user__right__field--input
-        = f.password_field :password_confirmation, autocomplete: "resourcespassword" 
-      = f.submit "登録する", class: 'user__right__actions'
+    .user__right__field
+      = form_for(current_user) do |f|
+          .field-label
+            = f.label :name
+          .field-input
+            = f.text_field :name, autofocus: true
+        .field
+          .field-label
+            = f.label :email
+          .field-input
+            = f.email_field :email
+    = f.submit "登録する", class: 'user__right__actions'
 
 .footer

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -28,7 +28,7 @@
         = f.label :パスワード（6文字以上）
         - if @minimum_password_length
           %em 
-        %br/
+        %br/  
       .user__right__field--input
         = f.password_field :password, autocomplete: "new-password"
       .user__right__field--label

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -20,7 +20,7 @@
         = f.label :ユーザー名
         %br/
       .user__right__field--input
-        = f.email_field :name, autofocus: true, autocomplete: "name"
+        = f.text_field :name, autofocus: true, autocomplete: "name"
       .user__right__field--label
         = f.label :'E-mail'
         %br/
@@ -29,7 +29,6 @@
       .user__right__field--label
         = f.label :パスワード（6文字以上）
         - if @minimum_password_length
-          %em 
         %br/  
       .user__right__field--input
         = f.password_field :password, autocomplete: "new-password"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -11,28 +11,31 @@
       = link_to '/users/sign_in' do
         .user__left__link--font  
           ログイン
-  .right
+  .user__right
     = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
       = render "devise/shared/error_messages", resource: resource
-      .field
+      .user__right__field--label
         = f.label :ユーザー名
         %br/
+      .user__right__field--input
         = f.email_field :name, autofocus: true, autocomplete: "name"
-      .field
+      .user__right__field--label
         = f.label :'E-mail'
         %br/
+      .user__right__field--input
         = f.email_field :email, autofocus: true, autocomplete: "email"
-      .field
+      .user__right__field--label
         = f.label :パスワード（6文字以上）
         - if @minimum_password_length
           %em 
         %br/
+      .user__right__field--input
         = f.password_field :password, autocomplete: "new-password"
-      .field
+      .user__right__field--label
         = f.label :パスワード（確認用）
         %br/
-        = f.password_field :password_confirmation, autocomplete: "resourcespassword"
-      .actions
-        = f.submit "登録する"
+      .user__right__field--input
+        = f.password_field :password_confirmation, autocomplete: "resourcespassword" 
+      = f.submit "登録する", class: 'user__right__actions'
 
 .footer

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,5 +1,5 @@
 .header
-  .header_left
+  .header__left
     = link_to '/' do
       StationRarry
 


### PR DESCRIPTION
# 概要
ユーザーの新規登録・情報編集画面のビューを実装した
# 変更・追加内容
user_scss/new.html.haml/edit.html.haml
# 影響範囲
usersテーブル
# 動作要件

# 補足

# その他
引き続き、ログイン画面とパスワードリセット画面、エラー時のメッセージの日本語化を実装します。route関係は別issueで実装します。
<!--必要に応じて項目の追加・削除を行って使用する-->
