### PR TITLE
ビューの微調整とカラーパレット作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .byebug_history
 app/assets/fonts/.DS_Store
 .DS_Store
+*.jpg

--- a/app/assets/stylesheets/_fonts.scss
+++ b/app/assets/stylesheets/_fonts.scss
@@ -1,7 +1,0 @@
-@font-face {
-  font-family: 'tegaki';
-  src: font-url('tegaki.ttf') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-  //DL先⇛http://pm85122.onamae.jp/851H_kktt.html
-}

--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -1,18 +1,21 @@
 .header{
   height: 60px;
   width:100%;
-  background-color: #333;
+  background-color: $shikagray;
   display: flex;
   justify-content: space-between;
   margin:auto 0;
+  z-index: 1;
   &__left{
     margin: auto 0;
-    color: white;
+    color: $purewhite;
+    ;
     margin: auto 10px;
     font-size: 25px;
     font-family: "TimesNewRoman";
     a{
-      color: white;
+      color: $purewhite;
+      ;
       text-decoration: none;
     }
   }
@@ -35,20 +38,18 @@
         margin: auto 10px;
         a{
           text-decoration: none;
-          color: white;
+          color: $purewhite;
+          ;
         }
       }
     }
   }
 }
-.main{
-  height: 680px;
-  width: 100%;
-}
+
 .footer{
   height: 50px;
   width:100%;
-  background-color: #333;
+  background-color: $shikagray;
   position: relative;
   &__credit{
     position: absolute;
@@ -56,7 +57,7 @@
     bottom: 5px;
     a{
       text-decoration: none;
-      color: white;
+      color:$purewhite;
       font-size:12px;
     }
   }

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -1,18 +1,18 @@
 .header{
   height: 60px;
   width:100%;
-  background-color: #333;
+  background-color:$shikagray;
   display: flex;
   justify-content: space-between;
   position: fixed;
   &__left{
     margin: auto 0;
-    color: white;
+    color:$purewhite;
     margin: auto 10px;
     font-size: 25px;
     font-family: 'TimesNewRoman';
     a{
-      color: white;
+      color:$purewhite;
       text-decoration: none;
     }
   }
@@ -24,15 +24,16 @@
         margin: auto 10px;
         a{
           text-decoration: none;
-          color: white;
+          color:$purewhite;
         }
       }
     }
   }
 }
 .main{
-  height: 680px;
+  height: 100vh;
   padding-top:60px;
+  background: $main-background;
   &__stationname{
     height:60px;
     width:100%;
@@ -40,20 +41,37 @@
     text-align: center;
     font-family: 'tegaki';
     font-size: 30px;
+    color:$purewhite;
   }
   &__images{
-    height: 100%;
-    margin: 40px;
+    margin: 0px 40px 40px 40px;
+    height: calc(100vh - 170px);
     display: flex;
     justify-content: space-around;
     flex-wrap: wrap;
+    overflow: scroll;
+    
     &__image{
-      height: 300px;
-      width: 300px;
-      line-height: 300px;
+      height: 400px;
+      width: 400px;
+      line-height: 400px;
       text-align: center;
-      margin: 30px;
-      background-color: yellow;
+      margin: 20px;
+      background: $imagecolor;
+      position: relative;
+
+      img{
+        object-fit: cover;
+      }
+      
+      &__comment{
+        height: 10px;
+        position: absolute;
+        top:180px;
+        left:20px;
+        color:$purewhite;
+        font-family : 'tegaki';
+      }
     }
   }
 }
@@ -61,9 +79,9 @@
 .footer{
   height: 50px;
   width:100%;
-  background-color: #333;
+  background-color:$shikagray;
   position: fixed;
-
+  bottom: 0;
   &__commentform{
     display: flex;
     justify-content: center;

--- a/app/assets/stylesheets/_user.scss
+++ b/app/assets/stylesheets/_user.scss
@@ -1,63 +1,113 @@
 .user {
-  height: 680px;
+  height: calc(100vh - 110px);
   display: flex;
   justify-content: flex-start;
   font-family: 'Hiragino Maru Gothic ProN';
-  margin-bottom: 60px;
-  
-  &__space {
-    height: 680px;
-    width: 500px;
-    background-color: blue;
-    margin-top: 60px;
+  position: relative;
+  padding-top: 60px;
+  overflow: hidden;
+
+  &__img {
+    img{
+    position: absolute;
+    top: 0;
+    left: 0;
+    -webkit-filter: blur(10px);
+    filter: blur(10px);
+    margin: -10px;  
+    width: calc(100% + 20px);
+    }
   }
 
   &__left {  
     margin-top: 60px;
+    position: absolute;
+    left: 500px;
+    top: 0px;
 
     &__title {
       height: 100px;
       width: 400px;
-      color:#333;
+      color:$shikagray;
       font-size: 40px;
       font-weight: bold;
       margin-top: 60px;
       text-align: center;
+      position: absolute;
+      left:350px;
+      text-shadow: $textshadow;
     }
 
     a{
       text-decoration: none;
     }
 
-    &__link {
+    &__newlink {
       height: 40px;
       width: 150px;
-      margin-left: 125px;
-      background-color: #333;
+      background-color:$shikagray;
       border-radius: 8px;
-      margin-top: 50px;
-     
-      &--font {
-        color: white;
-        font-size: 15px;
-        text-align: center;
-        line-height: 40px;
-      }
+      position: absolute;
+      top:550px;
+      left:380px;
+
+        &--font {
+          color: $purewhite;
+          font-size: 15px;
+          text-align: center;
+          line-height: 40px;
+        }
+    }
+    &__mainlink {
+      height: 40px;
+      width: 150px;
+      background-color:$shikagray;
+      border-radius: 8px;
+      position: absolute;
+      top:550px;
+      left:580px;
+      
+        &--font {
+          color: $purewhite;
+          font-size: 15px;
+          text-align: center;
+          line-height: 40px;
+      } 
+    }
+    &__backlink {
+      height: 40px;
+      width: 150px;
+      background-color:$shikagray;
+      border-radius: 8px;
+      position: absolute;
+      top:550px;
+      left:485px;
+      
+        &--font {
+          color: $purewhite;
+          font-size: 15px;
+          text-align: center;
+          line-height: 40px;
+      } 
     }   
   }
 
   &__right {
     width: calc(100% - 900px);
     margin-top: 60px;
+    left: 800px;
+    top: 100px;
+    position: absolute;
 
     &__field {
-
+      position: absolute;
       &--label {
-        height: 50px;
+        height: 25px;
         font-size: 20px;
-        color: #333;
-        margin-top: 30px;
+        color:$shikagray;
+        margin-top: 10px;
         margin-left: 50px;
+        text-shadow: $textshadow;
       }
 
       &--input {
@@ -65,6 +115,7 @@
           width: 400px;
           padding: 10px;
           margin-left: 50px;
+          background-color: $formcolor;
         }
       }    
     }
@@ -73,11 +124,14 @@
       height: 80px;
       width: 200px;
       margin-left: 160px;
-      background-color: #333;
+      background-color:$shikagray;
       border-radius: 10px;
+      border: none      ;
       margin-top: 50px;
-      color: white; 
+      color: $purewhite; 
       font-size: 30px;
+      position: absolute;
+      top:300px;
     }
 
     &__checkbox {
@@ -85,8 +139,19 @@
       width: 520px;
       text-align: center;
       margin-top: 50px;
-      color: #333;
+      color:$shikagray;
       font-size: 20px;
+      position: absolute;
+      top: 150px;
+      text-shadow: $textshadow;
+    }
+    &__error {
+      position: absolute;
+      top:500px;
+      left:50px;
+      color: $errorcolor;
+      font-weight: bold;
+      text-shadow: $textshadow;
     }
   } 
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "reset";
+@import "./config/fonts";
+@import "./config/colors";
 @import "index";
 @import "user";
 @import "show";
 @import "font-awesome";
-@import "fonts";

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -1,0 +1,7 @@
+$shikagray:#333;
+$purewhite:#ffffff;
+$main-background:linear-gradient(145deg, #56AEE3 0%, #FFA7D7 100%) no-repeat 0% 50% / 100% 100%;
+$imagecolor:linear-gradient(360deg, #EABA75 0%, #FFFBF4 100%) no-repeat 100% 50% / 100% 100%;
+$textshadow:0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff,0 0 1px #fff;
+$formcolor:azure;
+$errorcolor:red;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: 'tegaki';
+  src: font-url('tegaki.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+  //DL先⇛http://pm85122.onamae.jp/851H_kktt.html
+}

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,22 +2,22 @@
   = render partial: "maps/devise-header"
   
 .user
-
+  .user__img 
+    = image_tag "/assets/tokyo.jpg"
   .user__space
     = render partial: "maps/side-image"
 
   .user__left
     .user__left__title
       ユーザー情報編集
-    .user__left__link
+    .user__left__backlink
       = link_to '/' do
-        .user__left__link--font 
-          メイン画面
+        .user__left__backlink--font 
+          メイン画面へ戻る
 
   .user__right
     .user__right__field
     = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-      = render "devise/shared/error_messages", resource: resource
       .user__right__field--label
         = f.label :ユーザー名
         %br/
@@ -29,5 +29,6 @@
       .user__right__field--input
         = f.email_field :email, autofocus: true, autocomplete: "email"
       = f.submit "変更する", class: 'user__right__actions'
-
+    .user__right__error
+      = render "devise/shared/error_messages", resource: resource
 .footer

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,26 +2,26 @@
   = render partial: "maps/devise-header"
 
 .user
-
+  .user__img 
+    = image_tag "/assets/tokyo.jpg"
   .user__space
     = render partial: "maps/side-image"
 
   .user__left
     .user__left__title
       新規登録
-    .user__left__link
+    .user__left__newlink
       = link_to '/users/sign_in' do
-        .user__left__link--font  
+        .user__left__newlink--font  
           ログイン
-    .user__left__link
+    .user__left__mainlink
       = link_to '/' do
-        .user__left__link--font 
-          メイン画面
+        .user__left__mainlink--font 
+          メイン画面へ戻る
   
   .user__right
     .user__right__field
     = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-      = render "devise/shared/error_messages", resource: resource
       .user__right__field--label
         = f.label :ユーザー名
         %br/
@@ -45,5 +45,7 @@
       .user__right__field--input
         = f.password_field :password_confirmation, autocomplete: "resourcespassword" 
       = f.submit "登録する", class: 'user__right__actions'
+    .user__right__error
+      = render "devise/shared/error_messages", resource: resource
 
 .footer

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -2,25 +2,26 @@
   = render partial: "maps/devise-header"
 
 .user
-
+  .user__img 
+    = image_tag "/assets/tokyo.jpg"
   .user__space
     = render partial: "maps/side-image"
 
   .user__left
     .user__left__title
       ログイン
-    .user__left__link
+    .user__left__newlink
       = link_to '/users/sign_up' do
-        .user__left__link--font  
+        .user__left__newlink--font
           新規登録
     -# パスワード変更機能へのリンクを保留
     -# .user__left__link
     -#   = link_to '/users/password/new' do
     -#     .user__left__link--font 
     -#       パスワードを忘れた
-    .user__left__link
+    .user__left__mainlink
       = link_to '/' do
-        .user__left__link--font 
+        .user__left__mainlink--font
           メイン画面
   
   .user__right
@@ -40,5 +41,6 @@
       .user__right__checkbox
         = f.check_box :remember_me
         = f.label :パスワードを記憶させる
-
+    .user__right__error
+      = render "devise/shared/error_messages", resource: resource
 .footer 

--- a/app/views/maps/_main-images.html.haml
+++ b/app/views/maps/_main-images.html.haml
@@ -1,4 +1,4 @@
 .main__images__image
-  picture
+  = image_tag '/assets/yrp.jpg', alt: 'picture', height: '400px', width: '400px'
   .main__images__image__comment
-    comment
+    YRP野比駅前はなにもないですね・・・

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,12 +33,16 @@ ActiveRecord::Schema.define(version: 20191202082729) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",               default: "", null: false
-    t.string   "email",              default: "", null: false
-    t.string   "encrypted_password", default: "", null: false
-    t.integer  "points",                          null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.string   "name",                   default: "", null: false
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
   create_table "users_stations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# 概要
１．初期ログイン画面、ユーザー情報編集画面、新規登録画面、駅選択画面の装飾
２．deviseエラー文の微調整。
３．stylesheet以下にフォントとカラーパレット用のテンプレートを作成。色彩変更に強くなった？
# 変更・追加内容
同上
# 影響範囲
すべてのビュー
# 動作要件
動作保証はクロームVer.78のみ確認。
# 補足
可読性が低いので後ほどリファクタリング予定です。
ひとまずマスターとの整合性重視でマージします
# その他

<!--必要に応じて項目の追加・削除を行って使用する-->
