### PR TITLE
投稿フォーム　再改良

### DIFF
--- a/app/assets/stylesheets/_index.scss
+++ b/app/assets/stylesheets/_index.scss
@@ -53,10 +53,11 @@
   background-color:white;
   position: fixed;
   bottom: 0;
+
   &__commentform{
     display: flex;
     justify-content: flex-start;
-    margin-top: 10px;
+    margin-top: 10px; 
     position: relative;
     &__input{
       
@@ -67,7 +68,7 @@
         }
       
         &__boxFileSelect {
-          width: 200px;
+          width: 14.3%;
           height: 60px;
           text-align: center;
           line-height: 60px;
@@ -76,7 +77,7 @@
           font-size: 25px;
           color: $shikagray;
           margin-top: 0;
-          margin-left: 250px;
+          margin-left: 18%;
           cursor: pointer;
           font-family: 'tegaki';
           position: absolute; 
@@ -85,9 +86,9 @@
       
       &__text{  
         position: absolute;
-        width: 420px;
+        width: 30%;
         height: 60px;
-        margin-left: 460px;
+        margin-left: 33%;
         font-size: 20px;
         color: $shikagray;
         background-color: #CCFFFF;
@@ -98,9 +99,9 @@
 
     &__submit{
       position: absolute;
-      width: 150px;
+      width: 11%;
       height: 60px;
-      margin-left: 950px;
+      margin-left: 68%;
       border-radius: 3px;
       background: linear-gradient(-20deg, #99CCFF, #CCFFFF);
       font-family: 'tegaki';

--- a/app/views/images/_form.html.haml
+++ b/app/views/images/_form.html.haml
@@ -6,5 +6,5 @@
         = f.file_field :picture, class: 'footer__commentform__input__picture__input-default'
         .footer__commentform__input__picture__boxFileSelect 
           写真を選ぶ
-    = f.text_field :text, style: "border:none", class: 'footer__commentform__input__text', placeholder: "コメントを入力"
+    = f.text_field :text, maxlength: '21', style: "border:none", class: 'footer__commentform__input__text', placeholder: "コメントを入力（20文字まで）"
     = f.submit "投稿", style: "border:none", class: 'footer__commentform__submit' 


### PR DESCRIPTION
# 概要
　投稿フォーム部分について、テキストフィールドを20文字以内にする制約を実装。横幅に関して解像度に左右されないようpxから%に変更。
# 変更・追加内容
　images/_index.html.haml　index.scss
# 影響範囲
　投稿フォーム
# 動作要件

# 補足
　高さは解像度による大幅な狂いはないのでpx指定のまま
# その他

<!--必要に応じて項目の追加・削除を行って使用する-->
