### PR TITLE
ダブり解消

### DIFF
--- a/lib/tasks/api_process.rake
+++ b/lib/tasks/api_process.rake
@@ -21,6 +21,7 @@ namespace :api_process do
 
       end
     end
+
     class StationsAPI < TrainAPI
       PATH = 'Station'
       def self.fetch(params)
@@ -28,23 +29,31 @@ namespace :api_process do
 
       end
     end
+
     geo_west = 139.59928
     geo_east = 139.88175
     geo_north = 35.79100
     geo_south = 35.56214
+    kanagawa_names = ["向河原","武蔵小杉","武蔵中原","武蔵新城","津田山","武蔵溝ノ口"]
     jr_stations = StationsAPI.fetch({'odpt:operator': 'odpt.Operator:JR-East'})
+
     jr_stations.each do |jr_station|
       if jr_station["geo:lat"] <= geo_north  && jr_station["geo:lat"] >= geo_south && jr_station["geo:long"] <= geo_east && jr_station["geo:long"] >= geo_west
-        station_name_ja = jr_station["odpt:stationTitle"]["ja"]
-        station_name_en = jr_station["odpt:stationTitle"]["en"]
-        station_name_en.delete!("-")
-        station_geolat = jr_station["geo:lat"]
-        station_geolong = jr_station["geo:long"]
-        Station.create(name: station_name_ja, geolat:station_geolat, geolong:station_geolong, en_name: station_name_en)
-
+        if Station.where("name = ?", jr_station["odpt:stationTitle"]["ja"]) == []
+          station_name_ja = jr_station["odpt:stationTitle"]["ja"]
+          station_name_en = jr_station["odpt:stationTitle"]["en"]
+          station_name_en.delete!("-")
+          station_geolat = jr_station["geo:lat"]
+          station_geolong = jr_station["geo:long"]
+          Station.create(name: station_name_ja, geolat:station_geolat, geolong:station_geolong, en_name: station_name_en)
+        end
       end
     end
+    
+    Station.where(name: kanagawa_names).delete_all
+    
   end
+
   task make_points_table: :environment do
     class TrainAPI
       BASE_URL = 'https://api-tokyochallenge.odpt.org/api/v4/odpt:'


### PR DESCRIPTION
# 概要
stationsテーブルに同じ名前の駅（山手線:東京、中央線:東京など）が登録されてしまう不具合を解消しました。
# 変更・追加内容

# 影響範囲

# 動作要件

# 補足
DBをリセットしたあとrakeコマンドを実行すると件数が減ったstationsテーブルが作成されます。
# その他

<!--必要に応じて項目の追加・削除を行って使用する-->
