### PR TITLE
お試し

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -49,9 +49,7 @@ window.onload = function() {
       var icon2 = new Y.Icon('/assets/star1.png',{className: "icons2 "+ still_names[i]});
       var url2 = "/stations/" + still_ids[i] + "/images";
       var test_marker2 = new Y.Marker(new Y.LatLng(still_geolats[i],still_geolongs[i]),{icon: icon2});
-      markers2.push(test_marker2);
-      var marker2 = markers2[i];
-      marker2.bindInfoWindow('<a href="'+ url2 +'" class= "char1">'+still_names[i]+'駅の写真を投稿する</a>');
+      markers2.push(test_marker2)
 
       test_marker2.bind("mouseover", function(){
         var label = new Y.Label(new Y.LatLng(this.latlng.Lat,this.latlng.Lon), this.node[0].className.substr(7)+"駅");
@@ -63,9 +61,8 @@ window.onload = function() {
       })
 
       test_marker2.bind("click", function(){
-        $("p").parent().remove()
+        window.location.href = url2;
       })
-
     }
 
       map.addFeatures(markers);


### PR DESCRIPTION
# 概要
　お試しでmap上の駅名表示や各駅ページのリンクをいじりました。駅名はマウスオーバーで小さいポップアップ（要装飾）、リンクは駅のアイコンをクリックで良いかなと思います。
　
# 変更・追加内容
　index.js
# 影響範囲

# 動作要件

# 補足
　残念ながら変数がよく分からず、駅がどこをクリックしても同じ箇所になる（[i]が当たっていない？）ようなのと、駅名のポップアップのクラスが分からず装飾できませんでした。取りあえず理想的な動作？のイメージとして制覇済駅部分だけ変えてありますので、確認してください。マージするかは要相談。
# その他
　神奈川県の駅名を消すメソッドが消えているのかアイコンなどが表示されています。

<!--必要に応じて項目の追加・削除を行って使用する-->
