### PR TITLE
ユーザー情報編集エラーアラート

### DIFF
--- a/app/assets/javascripts/edit.js
+++ b/app/assets/javascripts/edit.js
@@ -1,0 +1,33 @@
+$(function(){
+  $(".user__right__actions").click(function(e){
+    var user_name = $("#user_name")
+    var user_email = $("#user_email")
+    e.preventDefault();
+    if (user_name[0].value == "" && user_email[0].value == ""){
+      Swal.fire({
+        text: '名前とメールアドレス入力してください',
+        icon: 'warning', 
+        showCancelButton: false,
+        background: 'white',
+        confirmButtonColor: '#99CCFF',
+      });
+    }else if (user_name[0].value == ""){
+      Swal.fire({
+        text: '名前を入力してください',
+        icon: 'warning', 
+        showCancelButton: false,
+        background: 'white',
+        confirmButtonColor: '#99CCFF',
+      });
+    }else if(user_email[0].value == ""){
+      Swal.fire({
+        text: 'メールアドレスを入力してください',
+        icon: 'warning', 
+        showCancelButton: false,
+        background: 'white',
+        confirmButtonColor: '#99CCFF',
+      });
+    };
+
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    if current_user.update(user_params) && current_user.name != ""
+    if current_user.update(user_params)
       redirect_to root_path
     else
       redirect_to edit_user_registration_path

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,3 +1,4 @@
+= javascript_include_tag 'edit.js'
 .header
   = render partial: "maps/devise-header"
   

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.assets.precompile += ['edit.js']
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,3 +11,4 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.precompile += %w( search.js )
 Rails.application.config.assets.precompile += %w( index.js )
 Rails.application.config.assets.precompile += %w( image.js )
+Rails.application.config.assets.precompile += %w( edit.js )


### PR DESCRIPTION
# 概要
ユーザー情報編集画面において、今までは名前が空の時は同じ画面に戻るけどからの名前は登録されてしまっているという状態だということが判明したので、javascriptで処理そのものを止めついでにアラートも出す機能も追加しました。
# 変更・追加内容

# 影響範囲

# 動作要件

# 補足

# その他

<!--必要に応じて項目の追加・削除を行って使用する-->
