### PR TITLE
もうjpgとjpegしか許さない！

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -36,7 +36,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_whitelist
-    %w(jpg jpeg gif png)
+    %w(jpg jpeg)
   end
 
   # Override the filename of the uploaded files:

--- a/app/views/images/index.html.haml
+++ b/app/views/images/index.html.haml
@@ -6,7 +6,7 @@
       :javascript
         $(function(){
           Swal.fire({ 
-          text: '写真を選択してください',
+          text: '写真(.jpg/.jpeg)を選択してください',
           icon: 'warning', 
           showCancelButton: false,
           background: 'white',


### PR DESCRIPTION
# 概要
　light.box使用に伴い投稿できるファイルの拡張子をjpgとjpegに制限
# 変更・追加内容
　undex.html.haml  image_uploader.rb
# 影響範囲

# 動作要件

# 補足

# その他

<!--必要に応じて項目の追加・削除を行って使用する-->
