### PR TITLE
これで行く！

### DIFF
--- a/app/assets/javascripts/memorial.js
+++ b/app/assets/javascripts/memorial.js
@@ -10,9 +10,10 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
-      showCancelButton: false,  
+      showConfirmButton: false,
+      showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(0,0,123,0.2)'
     });
   } if (rest == '75'){
@@ -23,9 +24,10 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
+      showConfirmButton: false,
       showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(255,211,13,0.2)'
     });
   } 
@@ -37,12 +39,13 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
+      showConfirmButton: false,
       showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(255,120,253,0.2)'
     });
-  }
+  } 
   if (rest == '0'){
     Swal.fire({ 
       title: '全駅制覇！',
@@ -51,9 +54,10 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
+      showConfirmButton: false,
       showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(255,211,13,0.2)'
     });
   } 

--- a/app/assets/javascripts/memorial_post.js
+++ b/app/assets/javascripts/memorial_post.js
@@ -1,17 +1,20 @@
+var ref = document.referrer; //前のページのURLを取得
+if(ref.indexOf('station') != -1){ //前のページのurlに()内が入っていたら$(function(){
 $(function(){
   var rest = gon.rest_station
   if ( rest == '30' || rest == '40' || rest == '50' || rest == '60' || rest == '70'){
     Swal.fire({ 
-      title: '残り'+rest+'駅!',
+      title: '残り'+rest+'駅！',
       text: '全駅制覇目指して頑張りましょう！',
       imageUrl: 'https://shikanai1993.s3-ap-northeast-1.amazonaws.com/uploads/image/picture/images_V1/star1.png',
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
-      showCancelButton: false,  
+      showConfirmButton: false,
+      showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
-      backdrop : ''
+      backdrop : 'rgba(0,0,123,0.2)'
     });
   } if (rest == '75'){
     Swal.fire({   
@@ -21,9 +24,10 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
+      showConfirmButton: false,
       showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(255,211,13,0.2)'
     });
   } 
@@ -35,12 +39,13 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
+      showConfirmButton: false,
       showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(255,120,253,0.2)'
     });
-  }
+  } 
   if (rest == '0'){
     Swal.fire({ 
       title: '全駅制覇！',
@@ -49,12 +54,14 @@ $(function(){
       imageWidth: 50,
       imageHeight: 50,
       imageAlt: 'おめでとうございます！',
+      showConfirmButton: false,
       showCancelButton: false,
+      timer : '3000',
       background: 'white',
-      confirmButtonColor: '#99CCFF',
       backdrop : 'rgba(255,211,13,0.2)'
     });
   } 
   else {
   }
 })
+}

--- a/app/views/images/index.html.haml
+++ b/app/views/images/index.html.haml
@@ -18,7 +18,6 @@
   - elsif flash[:first_photo]
     .omedetou
       = javascript_include_tag 'omedetou.js'
-      = javascript_include_tag 'memorial_post.js'
   .main__stationname
     = @station.name + "駅"
   .main__images

--- a/app/views/maps/index.html.haml
+++ b/app/views/maps/index.html.haml
@@ -1,5 +1,6 @@
 = javascript_include_tag 'index.js'
 = javascript_include_tag 'memorial.js'
+= javascript_include_tag 'memorial_post.js' 
 .header
   = render partial: "header"
 


### PR DESCRIPTION
# 概要
どうにもポイント獲得と連続してメモリアルアラートは出せない仕様のようなので、当該残駅数のときに、ログイン画面および駅の写真一覧（全ての駅）画面から遷移の時にアラートを出す仕組みとしました。
毎回OKボタンを押さなくても良いように、３秒で消えるアラートに改造しました。
# 変更・追加内容
 memorial.js  memorial_post.js  maps/index.html.haml
# 影響範囲

# 動作要件

# 補足

# その他

<!--必要に応じて項目の追加・削除を行って使用する-->
